### PR TITLE
Set width of Dask logo to be the same as the sidebar

### DIFF
--- a/dask_sphinx_theme/layout.html
+++ b/dask_sphinx_theme/layout.html
@@ -5,7 +5,9 @@
 {% block extrabody %}
 
 <nav id="explore-links">
-  <img class="caption" src="_static/images/dask-horizontal-white.svg"/>
+  <a href="https://dask.org">
+    <img class="caption" src="_static/images/dask-horizontal-white.svg"/>
+  </a>
 
   <ul>
     <li>

--- a/dask_sphinx_theme/static/css/explore.css
+++ b/dask_sphinx_theme/static/css/explore.css
@@ -23,6 +23,8 @@
 
 #explore-links .caption {
   flex: 0;
+  width: 300px;
+  max-height: 100%;
 }
 
 #explore-links a {


### PR DESCRIPTION
This was breaking on firefox before