### PR TITLE
Add http->https redirect to theme

### DIFF
--- a/dask_sphinx_theme/layout.html
+++ b/dask_sphinx_theme/layout.html
@@ -3,6 +3,8 @@
 {% set css_files = css_files + ["_static/css/explore.css"] %}
 {% set css_files = css_files + ["_static/css/nbsphinx.css"] %}
 
+{% set script_files = script_files + ["_static/js/custom.js"] %}
+
 {% block extrabody %}
 
 <nav id="explore-links">

--- a/dask_sphinx_theme/static/js/custom.js
+++ b/dask_sphinx_theme/static/js/custom.js
@@ -1,0 +1,3 @@
+if (location.protocol == 'http:') {
+ location.href = 'https:' + window.location.href.substring(window.location.protocol.length);
+}


### PR DESCRIPTION
This PR adds custom javascript as proposed in https://github.com/dask/dask/issues/4270#issuecomment-494133259 to perform `http:` -> `https:` redirects

Supersedes https://github.com/dask/dask/pull/4939