### PR TITLE
Add link to dask cloudprovider

### DIFF
--- a/dask_sphinx_theme/layout.html
+++ b/dask_sphinx_theme/layout.html
@@ -42,6 +42,7 @@
     <li>
       <a href="https://docs.dask.org/en/latest/setup.html">Deploy</a>
       <ul>
+        <li><a href="https://cloudprovider.dask.org/en/latest/"> Cloud Providers </a></li>
         <li><a href="https://yarn.dask.org/en/latest/"> Hadoop / Yarn </a></li>
         <li><a href="https://docs.dask.org/en/latest/setup/kubernetes-helm.html"> Helm </a></li>
         <li><a href="https://docs.dask.org/en/latest/setup/hpc.html"> HPC </a></li>


### PR DESCRIPTION
Added a link to the cloudprovider library in the deployment section. I assumed this list was alphabetical so threw it in the top.