### PR TITLE
Offset href links for header

### DIFF
--- a/dask_sphinx_theme/static/css/style.css
+++ b/dask_sphinx_theme/static/css/style.css
@@ -1,5 +1,11 @@
 @import url("theme.css");
 
+html {
+  /* Offset href links for header.
+   * See: https://css-tricks.com/fixed-headers-on-page-links-and-overlapping-content-oh-my/ */
+  scroll-padding-top: 50px
+}
+
 .rst-content h1,h2,h3,h4,h5{
   font-family: 'Garamond', 'Georgia', serif;
   font-weight: normal;


### PR DESCRIPTION
Previously href links would result in the top of each section being obscured by the header. This now fixes things so they look correct.

See https://css-tricks.com/fixed-headers-on-page-links-and-overlapping-content-oh-my/
for reference.

Thanks to @philippjfr for help figuring this out.