### PR TITLE
Use a lighter background color

### DIFF
--- a/dask_sphinx_theme/static/css/explore.css
+++ b/dask_sphinx_theme/static/css/explore.css
@@ -16,7 +16,7 @@
   height: 50px;
   line-height: 50px;
   text-align: center;
-  background-color: black;
+  background-color: #1a1a1a;
   color: #ECB172;
   display: flex;
 }
@@ -69,7 +69,7 @@
   top: 100%; /* align them to the bottom of the parent list item - again only necessary for older browsers */
   display: none; /* hide 'em */
   color: #ECB172;
-  background-color: black;
+  background-color: #1a1a1a;
 }
 
 #explore-links li:hover ul { /* when list items are hovered over, do this to lists contained within them... */

--- a/dask_sphinx_theme/static/css/style.css
+++ b/dask_sphinx_theme/static/css/style.css
@@ -47,7 +47,7 @@ html {
 }
 
 .wy-side-nav-search {
-  background-color: black;
+  background-color: #1a1a1a;
 }
 
 .wy-side-nav-search>div.version {
@@ -69,7 +69,7 @@ html {
 
 .wy-menu-vertical ul,
 .wy-side-scroll {
-  background-color: black;
+  background-color: #1a1a1a;
 }
 
 .wy-menu-vertical li.toctree-l2.current>a,
@@ -82,7 +82,7 @@ html {
 /* Mobile */
 
 .wy-nav-top {
-  background: black;
+  background: #1a1a1a;
 }
 
 .wy-nav-top a {


### PR DESCRIPTION
I find true black to be hard to look at, and find the crisp borders
between the menu/navbar and the lighter content distracting. Softening
the color to a dark grey seems to make things easier to look at IMO.
Many designers also agree:

- https://ianstormtaylor.com/design-tip-never-use-black/
- https://uxmovement.com/content/why-you-should-never-use-pure-black-for-text-or-backgrounds/
- https://graphicdesign.stackexchange.com/questions/25356/why-not-use-pure-black-000-and-pure-white-fff