### PR TITLE
Add test docs build and lighthouse CI

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,5 +1,5 @@
 name: Lighthouse
-on: push
+on: [push, pull_request]
 jobs:
   static-dist-dir:
     runs-on: ubuntu-latest

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,28 @@
+name: Lighthouse
+on: push
+jobs:
+  static-dist-dir:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+
+      - name: Install dask-sphinx-theme
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .
+
+      - name: Make example docs
+        run: |
+          cd docs
+          make html
+
+      - name: Run Lighthouse against example docs build
+        uses: treosh/lighthouse-ci-action@v2
+        with:
+          configPath: "./lighthouserc.json"
+          temporaryPublicStorage: true

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,7 +1,7 @@
 name: Lighthouse
 on: [push, pull_request]
 jobs:
-  static-dist-dir:
+  CI:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 __pycache__
+docs/_build
+**/*.egg-info

--- a/dask_sphinx_theme/static/js/custom.js
+++ b/dask_sphinx_theme/static/js/custom.js
@@ -1,3 +1,3 @@
-if (location.protocol == 'http:') {
- location.href = 'https:' + window.location.href.substring(window.location.protocol.length);
+if (location.protocol == "http:") {
+  //  location.href = 'https:' + window.location.href.substring(window.location.protocol.length);
 }

--- a/dask_sphinx_theme/static/js/custom.js
+++ b/dask_sphinx_theme/static/js/custom.js
@@ -1,3 +1,7 @@
 if (location.protocol == "http:") {
-  //  location.href = 'https:' + window.location.href.substring(window.location.protocol.length);
+  if (!window.location.href.includes("localhost")) {
+    location.href =
+      "https:" +
+      window.location.href.substring(window.location.protocol.length);
+  }
 }

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,52 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'Dask Sphinx Theme'
+copyright = '2020, Dask Contributors'
+author = 'Dask Contributors'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'dask_sphinx_theme'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,20 @@
+Welcome to Dask Sphinx Theme's documentation!
+=============================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+This is the official Sphinx theme for Dask documentation.  It extends the
+``sphinx_rtd_theme`` project, but adds custom styling and a navigation bar to
+additional Dask subprojects.
+
+When creating a Dask subproject you can include this theme by changing this
+line in your conf.py file
+
+.. code-block:: python
+
+   html_theme = 'dask_sphinx_theme'
+
+And by including ``dask_sphinx_theme`` as a requirement in your documentation
+installation.

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -3,5 +3,9 @@
     "collect": {
       "staticDistDir": "./docs/_build/html"
     }
+  },
+  "assertions": {
+    "categories:performance": ["warn", { "minScore": 0.8 }],
+    "categories:accessibility": ["error", { "minScore": 0.9 }]
   }
 }

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -3,7 +3,9 @@
     "assert": {
       "assertions": {
         "categories:performance": ["warn", { "minScore": 0.9 }],
-        "categories:accessibility": ["warn", { "minScore": 1 }]
+        "categories:accessibility": ["warn", { "minScore": 1 }],
+        "uses-long-cache-ttl": "off",
+        "uses-http2": "off"
       }
     },
     "collect": {

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,0 +1,7 @@
+{
+  "ci": {
+    "collect": {
+      "staticDistDir": "./docs/_build/html"
+    }
+  }
+}

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,11 +1,13 @@
 {
   "ci": {
+    "assert": {
+      "assertions": {
+        "categories:performance": ["warn", { "minScore": 0.8 }],
+        "categories:accessibility": ["error", { "minScore": 0.9 }]
+      }
+    },
     "collect": {
       "staticDistDir": "./docs/_build/html"
     }
-  },
-  "assertions": {
-    "categories:performance": ["warn", { "minScore": 0.8 }],
-    "categories:accessibility": ["error", { "minScore": 0.9 }]
   }
 }

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -2,8 +2,8 @@
   "ci": {
     "assert": {
       "assertions": {
-        "categories:performance": ["warn", { "minScore": 0.8 }],
-        "categories:accessibility": ["error", { "minScore": 0.9 }]
+        "categories:performance": ["warn", { "minScore": 0.9 }],
+        "categories:accessibility": ["warn", { "minScore": 1 }]
       }
     },
     "collect": {


### PR DESCRIPTION
[Lighthouse CI](https://github.com/GoogleChrome/lighthouse-ci) is a tool for automatically running [Google Lighthouse](https://developers.google.com/web/tools/lighthouse) on a website as part of your CI testing.

> Lighthouse is an open-source, automated tool for improving the quality of web pages. You can run it against any web page, public or requiring authentication. It has audits for performance, accessibility, progressive web apps, SEO and more.

This PR adds a test Sphinx docs page which builds using the theme. I've also added a GitHub Actions workflow which will then run Lighthouse against it and it should provide a performance report.

This CI generates reports like [this one](https://storage.googleapis.com/lighthouse-infrastructure.appspot.com/reports/1581077486743-5581.report.html).

It seems they are still working on adding a feature where the report is automatically linked in a comment on the PR, but should be available soon (see treosh/lighthouse-ci-action#22). For now you have to dig into the CI output to find it.

You can then configure the CI to pass/fail based on either [assertions](https://github.com/GoogleChrome/lighthouse-ci/blob/master/docs/assertions.md) (does my site meet a minimum performance/accessibility/seo score) and/or [download budgets](https://github.com/GoogleChrome/budget.json) (is my JavaScript less than 150KB, is my total download less than 500KB). I've added some but set them to warn only.