### PR TITLE
Run workflow on tags

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -2,8 +2,6 @@ name: Push to PyPI
 
 on:
   push:
-    branches:
-      - master
     tags:
       - "*"
 
@@ -26,13 +24,11 @@ jobs:
           python -m pip install -e .
 
       - name: Build dask-sphinx-theme dist
-        if: success() && startsWith(github.event.ref, 'refs/tags')
         run: |
           python -m pip install wheel twine
           python setup.py sdist bdist_wheel
 
       - name: Publish dask-sphinx-theme
-        if: success() && startsWith(github.event.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@master
         with:
           user: __token__

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -2,35 +2,38 @@ name: Push to PyPI
 
 on:
   push:
-    branches: master
+    branches:
+      - master
+    tags:
+      - "*"
 
 jobs:
   publish:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v1
+      - name: Checkout
+        uses: actions/checkout@v1
 
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.7
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
 
-    - name: Install dask-sphinx-theme
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install -e .
+      - name: Install dask-sphinx-theme
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .
 
-    - name: Build dask-sphinx-theme dist
-      if: success() && startsWith(github.event.ref, 'refs/tags')
-      run: |
-        python -m pip install wheel twine
-        python setup.py sdist bdist_wheel
-    
-    - name: Publish dask-sphinx-theme
-      if: success() && startsWith(github.event.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        user: __token__
-        password: ${{ secrets.pypi_token }}
+      - name: Build dask-sphinx-theme dist
+        if: success() && startsWith(github.event.ref, 'refs/tags')
+        run: |
+          python -m pip install wheel twine
+          python setup.py sdist bdist_wheel
+
+      - name: Publish dask-sphinx-theme
+        if: success() && startsWith(github.event.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_token }}


### PR DESCRIPTION
I've updated the publish to PyPI workflow to only run on tags. I've also removed the checks as it should always stop if a step fails and we don't need to check for the tag ref as we only trigger on tags.