### PR TITLE
Add slack to theme comunity tab + contributing note

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,13 @@
 Dask is a community maintained project. We welcome contributions in the form of bug reports, documentation, code, design proposals, and more. 
 
 For general information on how to contribute see https://docs.dask.org/en/latest/develop.html.
+
+Installing the theme itself: 
+
+After following the contribution guidelines in the dask docs, you will still need to install the theme itself to see the chnages you made. At the root level of the repository run:
+
+`python -m pip install -e .`  
+
+After that you will be able to build the docs locally by doing `make html` in the `docs` directory. 
+
+

--- a/dask_sphinx_theme/layout.html
+++ b/dask_sphinx_theme/layout.html
@@ -82,6 +82,7 @@
             <li><a href="https://twitter.com/dask_dev">Twitter</a></li>
             <li><a href="https://blog.dask.org/"> Developer Blog </a></li>
             <li><a href="https://youtube.com/c/dask-dev"> YouTube Channel </a></li>
+            <li><a href="https://join.slack.com/t/dask/shared_invite/zt-mfmh7quc-nIrXL6ocgiUH2haLYA914g"> Slack </a></li>
             </ul>
         </li>
         </ul>


### PR DESCRIPTION
This PR adds 
- the slack signup link to the community tab of the theme. 
- A comment on the CONTRIBUTING.md about installing the theme. I was trying to check my changes locally and I wasn't able to build them properly by following the same guidelines showed in the dask docs. this was because I was missing the installation of the theme itself. I added a note on the CONTRIBUTING.md about it. 