### PR TITLE
Pin `sphinx_rtd_theme >= 0.5.2`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-sphinx_rtd_theme
+sphinx_rtd_theme >= 0.5.2


### PR DESCRIPTION
The recent `docutils` 0.17 release has some incompatibility issues with `sphinx_rtd_theme` which causes things like, for example bulleted lists, to be rendered incorrectly (https://github.com/readthedocs/sphinx_rtd_theme/issues/1115). The PR ensures that we're using the latest `sphinx_rtd_theme` release, which handles [pinning `docutils<0.17`](
https://github.com/readthedocs/sphinx_rtd_theme/blob/05807985d6553993939754b6166664c7e80de481/setup.py#L121).

NOTE: The reason I'm proposing we pin `sphinx_rtd_theme` instead of `docutils` directly is that I recently discovered readthedocs.org implicitly pins `sphinx-rtd-theme<0.5` (xref https://github.com/readthedocs/readthedocs.org/issues/8230), which can lead to discrepancies between local and remote documentation builds. Pinning `sphinx_rtd_theme >= 0.5.2` as this PR suggests will allow us to both avoid the `docutils=0.17` rendering issue as well as minimize discrepancies between local builds and what happends on readthedocs.org