### PR TITLE
Add scroll offset

### DIFF
--- a/dask_sphinx_theme/static/css/style.css
+++ b/dask_sphinx_theme/static/css/style.css
@@ -5,6 +5,12 @@
   --dask-light: #ecb172;
 }
 
+html {
+  /* Offset href links for header.
+	 * See: https://css-tricks.com/fixed-headers-on-page-links-and-overlapping-content-oh-my/ */
+  scroll-padding-top: 4em;
+}
+
 code {
   color: var(--dask-dark);
 }


### PR DESCRIPTION
Closes #57 

Thanks for flagging this @jrbourbeau. This got lost in the migration. Switching to use relative units and matching the new `.dask-nav` class.