### PR TITLE
Remove dask logo background?

### DIFF
--- a/dask_sphinx_theme/static/css/style.css
+++ b/dask_sphinx_theme/static/css/style.css
@@ -9,11 +9,6 @@ code {
   color: var(--dask-dark);
 }
 
-body {
-  background-image: url("../images/background.png");
-  background-repeat: repeat;
-}
-
 .container,
 .container-lg,
 .container-md,


### PR DESCRIPTION
Just opening for discussion. Personally, I find the dask logo "wallpaper" on the right side of the page a little distracting, and I'd prefer a visually cleaner look with no background. Just curious if others feel the same way, or if we like having the branding.