### PR TITLE
Fix misrendering with new sphinx theme

### DIFF
--- a/dask_sphinx_theme/static/css/style.css
+++ b/dask_sphinx_theme/static/css/style.css
@@ -177,3 +177,8 @@ a {
 .sphinx-tabs {
   max-width: 100%;
 }
+
+ /* See https://github.com/dask/dask/issues/8236 */
+.classifier::before {
+  content: ": ";
+}

--- a/dask_sphinx_theme/static/css/style.css
+++ b/dask_sphinx_theme/static/css/style.css
@@ -178,7 +178,7 @@ a {
   max-width: 100%;
 }
 
- /* See https://github.com/dask/dask/issues/8236 */
+/* See https://github.com/dask/dask/issues/8236 */
 .classifier::before {
   content: ": ";
 }


### PR DESCRIPTION
This upstreams the CSS fix from https://github.com/dask/dask/pull/8296 into our shared sphinx theme to ensure API docs are rendered properly in all projects which use `dask-sphinx-theme` (xref https://github.com/dask/distributed/issues/5478) 

cc @jsignell @jacobtomlinson 