### PR TITLE
Pin upstream theme

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-sphinx-book-theme >= 0.1.5
+sphinx-book-theme==0.2.0


### PR DESCRIPTION
It looks like the upstream theme is going to go through some large changes in executablebooks/sphinx-book-theme#472. This should make our lives easier in the long run but breaks things today. Pinning for now so that we can migrate things over carefully when the new version is released.