### PR TITLE
Update `pre-commit` hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 21.9b0
+    rev: 22.3.0
     hooks:
       - id: black
         language_version: python3
@@ -13,6 +13,6 @@ repos:
       - id: flake8
         language_version: python3
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v2.4.1"
+    rev: "v2.6.2"
     hooks:
       - id: prettier


### PR DESCRIPTION
This should fix the 

```
 black....................................................................Failed
- hook id: black
- exit code: 1

Traceback (most recent call last):
  File "/home/runner/.cache/pre-commit/repor7rsy8v6/py_env-python3/bin/black", line 8, in <module>
    sys.exit(patched_main())
  File "/home/runner/.cache/pre-commit/repor7rsy8v6/py_env-python3/lib/python3.10/site-packages/black/__init__.py", line 1282, in patched_main
    patch_click()
  File "/home/runner/.cache/pre-commit/repor7rsy8v6/py_env-python3/lib/python3.10/site-packages/black/__init__.py", line 1268, in patch_click
    from click import _unicodefun  # type: ignore
ImportError: cannot import name '_unicodefun' from 'click' (/home/runner/.cache/pre-commit/repor7rsy8v6/py_env-python3/lib/python3.10/site-packages/click/__init__.py)
```

failure we're seeing on `main` 