### PR TITLE
Declare parallel safe

### DIFF
--- a/dask_sphinx_theme/__init__.py
+++ b/dask_sphinx_theme/__init__.py
@@ -13,3 +13,7 @@ def get_html_theme_path():
 # See http://www.sphinx-doc.org/en/stable/theming.html#distribute-your-theme-as-a-python-package
 def setup(app):
     app.add_html_theme("dask_sphinx_theme", path.abspath(path.dirname(__file__)))
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }


### PR DESCRIPTION
Fixes #78

the upstream theme is also parallel safe: https://github.com/executablebooks/sphinx-book-theme/pull/225
this theme doesn't add any event handlers so must also be safe