### PR TITLE
Add google tag manager tracking

### DIFF
--- a/dask_sphinx_theme/layout.html
+++ b/dask_sphinx_theme/layout.html
@@ -1,5 +1,33 @@
 {%- set favicon_url = favicon_url or ('_static/' + ('images/favicon.svg')) %} {%
-extends "sphinx_book_theme/layout.html" %} {%- block content %}
+extends "sphinx_book_theme/layout.html" %} {% block extrahead %}
+<!-- Google Tag Manager -->
+<script>
+  (function (w, d, s, l, i) {
+    w[l] = w[l] || [];
+    w[l].push({
+      "gtm.start": new Date().getTime(),
+      event: "gtm.js",
+    });
+    var f = d.getElementsByTagName(s)[0],
+      j = d.createElement(s),
+      dl = l != "dataLayer" ? "&l=" + l : "";
+    j.async = true;
+    j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
+    f.parentNode.insertBefore(j, f);
+  })(window, document, "script", "dataLayer", "GTM-P4GQM59");
+</script>
+<!-- End Google Tag Manager -->
+{% endblock %} {%- block content %}
+<!-- Google Tag Manager (noscript) -->
+<noscript
+  ><iframe
+    src="https://www.googletagmanager.com/ns.html?id=GTM-P4GQM59"
+    height="0"
+    width="0"
+    style="display: none; visibility: hidden"
+  ></iframe
+></noscript>
+<!-- End Google Tag Manager (noscript) -->
 
 <nav class="dask-nav container-fluid">
   <ul>

--- a/dask_sphinx_theme/layout.html
+++ b/dask_sphinx_theme/layout.html
@@ -1,34 +1,15 @@
 {%- set favicon_url = favicon_url or ('_static/' + ('images/favicon.svg')) %} {%
-extends "sphinx_book_theme/layout.html" %} {% block extrahead %}
-<!-- Google Tag Manager -->
-<script>
-  (function (w, d, s, l, i) {
-    w[l] = w[l] || [];
-    w[l].push({
-      "gtm.start": new Date().getTime(),
-      event: "gtm.js",
-    });
-    var f = d.getElementsByTagName(s)[0],
-      j = d.createElement(s),
-      dl = l != "dataLayer" ? "&l=" + l : "";
-    j.async = true;
-    j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
-    f.parentNode.insertBefore(j, f);
-  })(window, document, "script", "dataLayer", "GTM-P4GQM59");
-</script>
-<!-- End Google Tag Manager -->
-{% endblock %} {%- block content %}
+extends "sphinx_book_theme/layout.html" %} {%- block content %}
 <!-- Google Tag Manager (noscript) -->
 <noscript
   ><iframe
-    src="https://www.googletagmanager.com/ns.html?id=GTM-P4GQM59"
+    src="https://www.googletagmanager.com/ns.html?id={{ theme_google_tag_manager_id }}"
     height="0"
     width="0"
     style="display: none; visibility: hidden"
   ></iframe
 ></noscript>
 <!-- End Google Tag Manager (noscript) -->
-
 <nav class="dask-nav container-fluid">
   <ul>
     <li class="logo">
@@ -66,4 +47,28 @@ extends "sphinx_book_theme/layout.html" %} {% block extrahead %}
   </ul>
 </nav>
 
+{{ super() }} {%- endblock %} {% block footer %}
+<!-- Google Tag Manager -->
+<script>
+  (function (w, d, s, l, i) {
+    w[l] = w[l] || [];
+    w[l].push({
+      "gtm.start": new Date().getTime(),
+      event: "gtm.js",
+    });
+    var f = d.getElementsByTagName(s)[0],
+      j = d.createElement(s),
+      dl = l != "dataLayer" ? "&l=" + l : "";
+    j.async = true;
+    j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
+    f.parentNode.insertBefore(j, f);
+  })(
+    window,
+    document,
+    "script",
+    "dataLayer",
+    "{{ theme_google_tag_manager_id }}"
+  );
+</script>
+<!-- End Google Tag Manager -->
 {{ super() }} {%- endblock %}

--- a/dask_sphinx_theme/theme.conf
+++ b/dask_sphinx_theme/theme.conf
@@ -6,3 +6,4 @@ pygments_style = dask_sphinx_theme._pygments.style.DaskStyle
 [options]
 show_prev_next = False
 logo_link = _static/images/dask-horizontal-white.svg
+google_tag_manager_id = GTM-P4GQM59


### PR DESCRIPTION
Adding GTM to the dask theme since read the docs does not support google tag manager (you can only add GA-4 analytics IDs). If we confirm this is working, then we can remove the analytics ID from RTD.

cc @emilyvalentine @jacobtomlinson 