### PR TITLE
Add fix for downloading config files from GitHub

### DIFF
--- a/dask_sphinx_theme/ext/dask_config_sphinx_ext.py
+++ b/dask_sphinx_theme/ext/dask_config_sphinx_ext.py
@@ -19,10 +19,14 @@ class DaskConfigDirective(Directive):
     def run(self):
         location = self.options["location"]
         config = self.options["config"]
+        print(f"\n\n\n[file] {config = }\n\n\n")
         schema = self.options["schema"]
+        print(f"\n\n\n[file] {schema = }\n\n\n")
 
         config = get_remote_yaml(config)
+        print(f"\n\n\n{config = }\n\n\n")
         schema = get_remote_yaml(schema)
+        print(f"\n\n\n{schema = }\n\n\n")
 
         for k in location.split("."):
             # dask config does not have a top level key

--- a/dask_sphinx_theme/ext/dask_config_sphinx_ext.py
+++ b/dask_sphinx_theme/ext/dask_config_sphinx_ext.py
@@ -6,7 +6,11 @@ from docutils.parsers.rst import Directive, directives
 
 def get_remote_yaml(url):
     r = requests.get(url)
-    return yaml.safe_load(r.text)
+    try:
+        return yaml.safe_load(r.text)
+    except Exception as e:
+        print(f"Failed to load {url} with text {r.text}")
+        raise e
 
 
 class DaskConfigDirective(Directive):

--- a/dask_sphinx_theme/ext/dask_config_sphinx_ext.py
+++ b/dask_sphinx_theme/ext/dask_config_sphinx_ext.py
@@ -6,12 +6,12 @@ from docutils.parsers.rst import Directive, directives
 
 
 def get_remote_yaml(url):
-    r = requests.get(url, headers={'User-Agent': f'Dask sphinx theme {dask_sphinx_theme.__version__}'})
-    try:
-        return yaml.safe_load(r.text)
-    except Exception as e:
-        print(f"Failed to load {url} with text {r.text}")
-        raise e
+    r = requests.get(
+        url,
+        headers={"User-Agent": f"Dask sphinx theme {dask_sphinx_theme.__version__}"},
+    )
+    r.raise_for_status()
+    return yaml.safe_load(r.text)
 
 
 class DaskConfigDirective(Directive):
@@ -24,15 +24,10 @@ class DaskConfigDirective(Directive):
     def run(self):
         location = self.options["location"]
         config = self.options["config"]
-        print(f"\n\n\n[file] {config = }\n\n\n")
         schema = self.options["schema"]
-        print(f"\n\n\n[file] {schema = }\n\n\n")
 
-        print("Attempting to run get_remote_yaml(config)...")
         config = get_remote_yaml(config)
-        print(f"\n\n\n{config = }\n\n\n")
         schema = get_remote_yaml(schema)
-        print(f"\n\n\n{schema = }\n\n\n")
 
         for k in location.split("."):
             # dask config does not have a top level key

--- a/dask_sphinx_theme/ext/dask_config_sphinx_ext.py
+++ b/dask_sphinx_theme/ext/dask_config_sphinx_ext.py
@@ -23,6 +23,7 @@ class DaskConfigDirective(Directive):
         schema = self.options["schema"]
         print(f"\n\n\n[file] {schema = }\n\n\n")
 
+        print("Attempting to run get_remote_yaml(config)...")
         config = get_remote_yaml(config)
         print(f"\n\n\n{config = }\n\n\n")
         schema = get_remote_yaml(schema)

--- a/dask_sphinx_theme/ext/dask_config_sphinx_ext.py
+++ b/dask_sphinx_theme/ext/dask_config_sphinx_ext.py
@@ -1,3 +1,4 @@
+import dask_sphinx_theme
 import requests
 import yaml
 from docutils import nodes
@@ -5,7 +6,7 @@ from docutils.parsers.rst import Directive, directives
 
 
 def get_remote_yaml(url):
-    r = requests.get(url)
+    r = requests.get(url, headers={'User-Agent': f'Dask sphinx theme {dask_sphinx_theme.__version__}'})
     try:
         return yaml.safe_load(r.text)
     except Exception as e:


### PR DESCRIPTION
Full context is here https://github.com/dask/dask/pull/11522

It looks like GitHub started blocking us downloading Dask config files for some reason. Stackoverflow recommended setting a custom `User-Agent`, which I've confirmed fixes things (at least for now -- again not sure what changed on the GitHub side. I can open a support ticket). 

cc @jacobtomlinson @phofl 